### PR TITLE
Make extract_edge.py run on sample dataset by default

### DIFF
--- a/label_tool/extract_edge.py
+++ b/label_tool/extract_edge.py
@@ -148,8 +148,9 @@ def visualize_two_images_side_by_side(img, overlaid_img, save_path):
     
     
 if __name__ == "__main__":
-    
-    if not os.path.exists(user_params.saved_edge_path):
+
+    if not os.path.exists(user_params.saved_edge_path)
+        print("Saved edge folder does not exist.. Creating folder \"", user_params.saved_edge_path, "\"to save images into")
         os.makedirs(user_params.saved_edge_path)
         
     # get all of dataset's images

--- a/label_tool/extract_edge.py
+++ b/label_tool/extract_edge.py
@@ -149,7 +149,7 @@ def visualize_two_images_side_by_side(img, overlaid_img, save_path):
     
 if __name__ == "__main__":
 
-    if not os.path.exists(user_params.saved_edge_path)
+    if not os.path.exists(user_params.saved_edge_path):
         print("Saved edge folder does not exist.. Creating folder \"", user_params.saved_edge_path, "\"to save images into")
         os.makedirs(user_params.saved_edge_path)
         

--- a/label_tool/user_params.py
+++ b/label_tool/user_params.py
@@ -12,8 +12,8 @@ canny_std_multiplier = 1.8  # For canny algorithm, values from 1 to 2 usually wo
 denoise_kernel_size = 5  # For blurring, 5 usually works the best
 
 # '040119_PtK1_S01_01_phase_3_DMSO_nd_03', '040119_PtK1_S01_01_phase_2_DMSO_nd_02', '040119_PtK1_S01_01_phase_2_DMSO_nd_01', '040119_PtK1_S01_01_phase_ROI2', '040119_PtK1_S01_01_phase'
-a_dataset = '040119_PtK1_S01_01_phase'
-img_root_path = '../assets/' + a_dataset + '/img/'  # original image folder path
+a_dataset = '040119_PtK1_S01_01_phase_ROI2'
+img_root_path = './assets/' + a_dataset + '/img_all/'  # original image folder path
 saved_edge_path = 'generated_edge/' + a_dataset   # folder to save edges
 saved_segment_path = 'generated_segmentation/' + a_dataset  # folder to save segmentations
 saved_edge_user_params_path = 'generated_explore_edge/' + a_dataset


### PR DESCRIPTION
To test functionality, I wanted to run extract_edge.py on the dataset provided in folder assets/040119_PtK1_S01_01_phase_ROI2 however the path in user_params.py is not set to a path that exists. I set it to the dataset provided. This is a minor tweak, since most people will be inputting their own datasets, but thought it would be nice for extract_edge.py to work out of the box.

Not sure if this has the same behavior on other systems (I'm using Windows 11), in user_params.py in label_tool the previous folder (../) is not the root folder. Instead I found that (./) is actually the root, which seems weird since user_params.py in in label_tool not the root.